### PR TITLE
Fixing README for lsstdesc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # OpSimSummary
 
-[![Build Status](https://travis-ci.org/rbiswas4/OpSimSummary.svg?branch=master)](https://travis-ci.org/rbiswas4/OpSimSummary)
+[![Build Status](https://travis-ci.org/LSSTDESC/OpSimSummary.svg?branch=master)](https://travis-ci.org/LSSTDESC/OpSimSummary)
 
 `OpSimSummary` is a codebase developed to interact with the LSST Operations Simulator outputs. Currently they are used for catalog Time Domain Simulations. 
 This includes a library that can be called by simulation codes to obtain the set of LSST pointings observing a particular point, as well as a script which uses
 the library and precomputes such pointings and store them in an observation library. This storage is in a format specific to [`SNANA`](http://snana.uchicago.edu/)
 
-- Documentation is hosted at [github_pages](https://rbiswas4.github.io/OpSimSummary/build/html/index.html)
+- Documentation is hosted at [github_pages](https://lsstdesc.github.io/OpSimSummary/build/html/index.html)
 
 ## Installation  and Software Requirements
 
-`opsimsummary` runs on either python 2.7 or 3.6+ . The list of required software to run `opsimsummary` is listed [here](./install/requirements.md). For installation methods, please see the [documentation](https://rbiswas4.github.io/OpSimSummary/build/html/Installation.html)
+`opsimsummary` runs on either python 2.7 or 3.6+ . The list of required software to run `opsimsummary` is listed [here](./install/requirements.md). For installation methods, please see the [documentation](https://lsstdesc.github.io/OpSimSummary/build/html/Installation.html)
 


### PR DESCRIPTION
Since moving the repository location and ownership some of the previous
links have been broken. This is to fix these links.
	modified:   README.md