### PR TITLE
Fixed the error messg on travis with help from travis community: http…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
     - "2.7"
@@ -14,10 +15,10 @@ install:
     - export PATH="$HOME/miniconda/bin:$PATH"
     - hash -r
     - conda config --set always_yes yes --set changeps1 no
-    - travis_wait 16 ./install/install_all.sh
+    - travis_wait 20 ./install/install_all.sh
 cache:
   directories:
   - $HOME/miniconda.tarball
   timeout: 1600
 script:
-    - py.test tests/ 
+    - py.test tests

--- a/install/pip-requirements.txt
+++ b/install/pip-requirements.txt
@@ -1,5 +1,5 @@
-pytest
+pytest=3.2.5
 pytest-cov
 python-coveralls
-coverage
+coverage=4.5.4
 matplotlib


### PR DESCRIPTION
…s://travis-ci.community/t/plugin-pytest-cov-could-not-be-loaded-using-miniconda-2/4465/3

particularly @dominic Jodoin

- problem: While the travis tests were passing on python 3.6, the tests
failed on travis with version 2.7 with no change of code on my part
since successful tests.
- Posted this to the travis community and @dominic guessed that the
changes had to do with travis migrating the underlying linux
distribution from `trusty` to `xenial`
- Hardcoding the distribution did not change results, but @dominic ran a
diff against my latest successful builds showing me the differences in
package versions (due to `pip install -U` in my install script)
- I had first tried (due to changes in pytest deprecating `py.test` vs
`pytest` in pytest version 3.3) to pin pytest < 3.3.0 but this did not
work.
- Using the diff for dominic, I pinned to the specific version of
`pytest` used before and was successful. Thanks!

	modified:   .travis.yml
	modified:   install/pip-requirements.txt