### PR TITLE
Drop python 2.7 from travis tests. Test Python 3.7 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
-dist: trusty
+dist:
+    - xenial
+    - bionic
 language: python
 python:
-    - "2.7"
     - "3.6"
+    - "3.7"
 before_install:
     - chmod +x ./install/*.sh
 install:


### PR DESCRIPTION
Dropping python 2.7 support. 

This simply means we change the travis tests to work only on python 3.6 (as before) and 3.7 (new addition). We will not be running any CI for python 2.7. We will not change any code to remove python 2.7 compatibility till the need arises. 

Python 3.7 is not available automatically on `trusty` and `trusty` is also beyond end of life support. Instead we will test on `xenial` and `bionic`

	modified:   .travis.yml

Fixes #307 