### PR TITLE
Issue#325/proposal tables

### DIFF
--- a/opsimsummary/simlib.py
+++ b/opsimsummary/simlib.py
@@ -113,8 +113,7 @@ class SimlibMixin(object):
         # report a host on which the calculations are done. either from
         # constructor parameters or from the system hostname utility 
         if host is None:
-            proc = subprocess.Popen('hostname', stdout=subprocess.PIPE)
-            host, err = proc.communicate()
+            host = os.getenv( 'HOSTNAME' )
         x = (('user', user),
              ('host', host),
              ('pixelSize', pixelSize),
@@ -257,7 +256,7 @@ class SimlibMixin(object):
         s += 'LIBID: {0:10d}'.format(fieldID) +'\n'
         if fieldtype is not None:
             s += 'Field: {}\n'.format(fieldtype)
-        tmp = 'RA: {0:+10.6f} DECL: {1:+10.6f}   NOBS: {2:10d} MWEBV: {3:5.2f}'
+        tmp = 'RA: {0:+10.6f} DEC: {1:+10.6f}   NOBS: {2:10d} MWEBV: {3:5.2f}'
         tmp += ' PIXSIZE: {4:5.3f}'
         s += tmp.format(ra, dec, nobs, mwebv, self.pixelSize) + '\n'
         # s += 'LIBID: {0:10d}'.format(fieldID) + '\n'
@@ -653,7 +652,7 @@ class FieldSimlib(object):
     meta : dict
         metadata associated with the field, which has at least the following
         keys:
-        LIBID, RA, DECL, MWEBV, NOBS, PIXSIZE
+        LIBID, RA, DEC, MWEBV, NOBS, PIXSIZE
     data : `~pd.DataFrame` object with the observations and having at least the
         following columns: 'MJD', 'IDEXPT', 'FLT', 'GAIN', 'NOISE', 'SKYSIG',
         'PSF1', 'PSF2', 'PSFRatio', 'ZPTAVG', 'ZPTERR', 'MAG']. The meanings of

--- a/scripts/make_simlibs_no_proposal.py
+++ b/scripts/make_simlibs_no_proposal.py
@@ -140,8 +140,8 @@ def write_genericSimlib(simlibFilename,
         avail = hids - vetoed_hids
     else:
         avail = hids
-    
-    surveydf = surveydf.loc[avail].query('numVisits >= @minVisits ')
+
+    surveydf = surveydf.loc[list(avail)].query('numVisits >= @minVisits ')
     surveyPix = simlibs.get_surveyPix(surveydf, numFields=numFields, rng=rng)
     totalfields = len(surveydf)
 
@@ -165,10 +165,10 @@ def write_genericSimlib(simlibFilename,
     fields = simlibs.simlibs_for_fields(surveyPix, mwebv=mwebv)
 
     # Area of our selected footprint in sq. deg 
-    area = hp.nside2pixarea(nside, degrees=True) * np.float(totalfields)
+    area = hp.nside2pixarea(nside, degrees=True) * np.float64(totalfields)
 
     # Area of our selected footprint in solid angle (Used by SNANA for simulation)
-    solidangle = hp.nside2pixarea(nside, degrees=False) * np.float(totalfields)
+    solidangle = hp.nside2pixarea(nside, degrees=False) * np.float64(totalfields)
  
     print('Going to write simlib file {0} for opsim output\n')
     # This is not very reliable
@@ -262,8 +262,8 @@ if __name__ == '__main__':
                         dest='No_get_ddf_pixels', action='store_false')
     parser.add_argument('--no_write_wfd_simlib', help='Whether to write out WFD simlib, defaults to writing it out',
                         dest='write_wfd_simlib', action='store_false')
-    parser.add_argument('--opsimversion', help='version of opsim used lsstv3|lsstv4, defaults to lsstv3',
-                        default='lsstv3')
+    parser.add_argument('--opsimversion', help='version of opsim used lsstv3|lsstv4|, defaults to fbsv2',
+                        default='fbsv2')
     parser.add_argument('--summaryTableName', help='name of Summary Table Summary|SummaryAllProps, defaults to "Summary"',
                         default='Summary')
     parser.add_argument('--ddf_surveypix_file', help='absolute path to DDF surveypix_file, defaults to `None`',


### PR DESCRIPTION
Changes in scripts/make_simlibs_no_proposal.py:

1. Fix an issue where (at least recent) pandas doesn't want to be indexed by a set.
2. Replace np.float() with np.float64() to avoid deprecation warnings.
3. Use os.getenv( "HOSTNAME" ) go get hostname, instead of a subprocess run of hostname, to avoid a binary string in the simlib header.
4. Update the default opsimversion to fbsv2, which is what's needed for "no proposal tables" versions of the opsim db files (and is needed for recent opsim  db files).  (They're actually on fbsv3, but I'm told there's no schema changes, and the rest of OpSimSummary doesn't know about fbsv3.)
5. Replace DECL with DEC as per SNANA's current standard (cf: Rick Kessler).